### PR TITLE
Prevent text reflow when selecting a road closing.

### DIFF
--- a/public/css/sass-modules/_panelList.scss
+++ b/public/css/sass-modules/_panelList.scss
@@ -64,7 +64,7 @@
     border-left-width: 0;
     display: block;
     margin: 0;
-    padding: .5rem .5rem (6rem/16) .5rem;
+    padding: .5rem (6rem/16) .125rem .5rem;
     transition: border-width .15s ease-in-out, padding .15s ease-in-out;
 
     &:after {


### PR DESCRIPTION
Due to an error in the SASS, the road closing description would reflow during the reveal animation after users click on the road closing. This commit prevents the reflow, and refines the vertical alignment of items in the road closings list.