### PR TITLE
Fix for a broken CSS animation

### DIFF
--- a/public/css/sass-modules/_panelList.scss
+++ b/public/css/sass-modules/_panelList.scss
@@ -113,8 +113,9 @@
         }
 
         &:before {
-            -webkit-transform: scaleY(-1) translateY((5rem/16));
-            transform: scaleY(-1) translateY((5rem/16));
+            $translateDistance: (5rem/16);
+            -webkit-transform: scaleY(-1) translateY($translateDistance);
+            transform: scaleY(-1) translateY($translateDistance);
         }
     }
     .title {


### PR DESCRIPTION
It looks like an update to the SASS compiler does not process fractions passed as arguments to translateY(). When the fraction is escaped by the SASS compiler into the production CSS, it invalidates the entire CSS declaration, preventing the CSS animation from happening. To workaround this issue, I've introduced a variable that has the fraction, and passed that variable as the argument to translateY().