### PR TITLE
Clarified language relating to segment to make more intuitive

### DIFF
--- a/language/en_US/LC_MESSAGES/labels.po
+++ b/language/en_US/LC_MESSAGES/labels.po
@@ -242,16 +242,16 @@ msgstr "Title"
 msgid "segment"
 msgid_plural "segments"
 msgstr[0] "Segment"
-msgstr[1] "Segments"
+msgstr[1] "Waze Segments"
 
 msgid "segment_add"
-msgstr "New Segment"
+msgstr "New Waze Segment"
 
 msgid "segment_edit"
-msgstr "Edit Segment"
+msgstr "Edit Waze Segment"
 
 msgid "segment_delete"
-msgstr "Delete Segment"
+msgstr "Delete Waze Segment"
 
 msgid "street"
 msgid_plural "streets"

--- a/language/en_US/LC_MESSAGES/messages.po
+++ b/language/en_US/LC_MESSAGES/messages.po
@@ -33,7 +33,7 @@ msgid "notification_subject %s"
 msgstr "%s Notification"
 
 msgid "event_disclaimer"
-msgstr "Entering in a closure does not waive any requirements for seeking appropriate approvals and permits."
+msgstr "Entering in a closure does not waive any requirements for seeking appropriate approvals and permits. After you complete this section, navigate to 'Waze Segments' to add a closure to Waze/Google Maps."
 
 msgid "employee_authentication_help"
 msgstr ""


### PR DESCRIPTION
I added to the event details which first when creating a closure on inRoads so that staff know/are reminded to create a segment to go along with it. I also edited the button called 'segment' to 'waze segment' to make it clearer what it is doing. 